### PR TITLE
Support for unsubscribe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ let currentState = todoStore.getState();
 todoStore.dispatch(action); 
 
 // adds a state change listener
-todoStore.subscribe(
+let unsubscribe = todoStore.subscribe(
    state => console.log('Received new store state: ' + state);
 );
+
+// when the subscription is not needed anymore
+unsubscribe();
 ```
 
 ### Using the Angular 2 Redux Store

--- a/src/ReduxStore.ts
+++ b/src/ReduxStore.ts
@@ -35,7 +35,7 @@ export abstract class ReduxStore {
     }
 
     subscribe(listener: Function) {
-        this.store.subscribe(() => listener(this.getState()));
+        return this.store.subscribe(() => listener(this.getState()));
     }
 
 }


### PR DESCRIPTION
First, I like the simplicity of this component. But, current implementation of `ReduxStore` seems to miss returning the unsubscribe function from original `store.subscribe()` call.

See: http://rackt.org/redux/docs/api/Store.html#subscribe

> ### `subscribe(listener)`
> 
> ...
> ##### Returns
> 
> (_Function_): A function that unsubscribes the change listener
