### PR TITLE
Add typings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   "dependencies": {},
   "devDependencies": {
     "typescript": "^1.7.3"
-  }
+  },
+  "typings": "./lib/index.d.ts"
 }


### PR DESCRIPTION
Adds the typings file to the package.json to adhere to typings for NPM Packages:
https://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html
